### PR TITLE
HTTP proxy client for use during development

### DIFF
--- a/env/dev/resources/config.edn
+++ b/env/dev/resources/config.edn
@@ -1,4 +1,5 @@
 {:slackbot {:logging    {:level :debug}
+            :proxy      {:bot-api-url "https://slackbot.crink.io"}
             :slack      {:api-url "https://slack.com/api"}
             :web-server {:host "localhost"
                          :port "8080"}}}

--- a/env/dev/src/slackbot_dev.clj
+++ b/env/dev/src/slackbot_dev.clj
@@ -19,6 +19,7 @@
    [mount.core :as mount :refer [defstate]]
    [slackbot.database]
    [slackbot.database.migrations :as migrations]
+   [slackbot.proxy]
    [slackbot.logging]
    [slackbot.web-server]))
 

--- a/src/clojure/slackbot/config.clj
+++ b/src/clojure/slackbot/config.clj
@@ -25,6 +25,9 @@
 (s/def :slackbot.logging/level timbre/-levels-set)
 (s/def :slackbot.config/logging (s/keys :req-un [:slackbot.logging/level]))
 
+(s/def :slackbot.proxy/bot-api-url string?)
+(s/def :slackbot.config/proxy (s/keys :opt-un [:slackbot.proxy/bot-api-url]))
+
 (s/def :slackbot.slack/api-url string?)
 (s/def :slackbot.slack/client-id string?)
 (s/def :slackbot.slack/client-secret string?)
@@ -43,7 +46,8 @@
 (s/def :slackbot.config/slackbot (s/keys :req-un [:slackbot.config/database
                                                   :slackbot.config/logging
                                                   :slackbot.config/slack
-                                                  :slackbot.config/web-server]))
+                                                  :slackbot.config/web-server]
+                                         :opt-un [:slackbot.config/proxy]))
 
 (s/def :slackbot/config (s/keys :req-un [:slackbot.config/slackbot]))
 

--- a/src/clojure/slackbot/core.clj
+++ b/src/clojure/slackbot/core.clj
@@ -20,6 +20,7 @@
    [mount.core :as mount]
    [slackbot.database]
    [slackbot.database.migrations :as migrations]
+   [slackbot.proxy]
    [slackbot.logging]
    [slackbot.web-server]))
 

--- a/src/clojure/slackbot/proxy.clj
+++ b/src/clojure/slackbot/proxy.clj
@@ -1,0 +1,100 @@
+;; Copyright 2018 Chris Rink
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns slackbot.proxy
+  (:require
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [httpurr.client.aleph :as http]
+   [httpurr.status :as s]
+   [medley.core :refer [assoc-some]]
+   [mount.core :refer [defstate]]
+   [promesa.core :as p]
+   [taoensso.timbre :as timbre]
+   [slackbot.config :as config]))
+
+(defn my-ip-address
+  "Fetch my current IP address from Amazon."
+  []
+  (-> (http/get "https://checkip.amazonaws.com/")
+      (p/then (fn [{:keys [body] :as response}]
+                (cond
+                  (s/success? response)
+                  (str/trim-newline (slurp body))
+
+                  :else
+                  (throw
+                   (ex-info "Could not find my IP address" {:response response})))))
+      (deref)))
+
+(defstate current-ip
+  :start (my-ip-address))
+
+(defn proxy
+  "Send a proxy request to the specified `proxy-url`."
+  [{:keys [body headers query-string request-method uri]} proxy-url]
+  (let [url (str proxy-url uri)]
+    (->> {:body         body
+          :headers      headers
+          :method       request-method
+          :query-string query-string
+          :url          url}
+         (http/send!)
+         (deref))))
+
+(defn add-forwarded-header
+  "Add the `X-Forwarded-For` header to a proxied request."
+  [{:strs [x-forwarded-for] :as headers}]
+  (cond->> current-ip
+    (some? x-forwarded-for) (str x-forwarded-for ", ")
+    :always                 (assoc headers "x-forwarded-for")))
+
+(defn wrap-proxy-requests
+  "Middleware which proxies requests to a remote server if `request-matches?`
+  returns true for the request.
+
+  If the `[:slackbot :proxy :bot-api-url]` configuration option is not supplied,
+  then requests will be proxied and `handler` will be returned as by `identity`."
+  [handler request-matches?]
+  (if-let [proxy-url (config/config [:proxy :bot-api-url])]
+    (fn [req]
+      (if (request-matches? req)
+        (-> req
+            (update :headers add-forwarded-header)
+            (proxy proxy-url))
+        (handler req)))
+    handler))
+
+(defn wrap-proxy-split-requests
+  "Middleware which proxies requests to a remote server as the _real_ request, but
+  has the current host process the response and emit a debug log for inspection.
+
+  If the `[:slackbot :proxy :bot-api-url]` configuration option is not supplied,
+  then requests will be proxied and `handler` will be returned as by `identity`."
+  [handler]
+  (if-let [proxy-url (config/config [:proxy :bot-api-url])]
+    (fn [req]
+      (do
+        ;; Handle the request internally, discarding the results
+        (let [internal-response (handler req)]
+          (timbre/debug
+           (str "INTERNAL RESPONSE:" \newline
+                (with-out-str (pprint/pprint internal-response)))))
+
+        ;; Proxy the request to the remote server and return it
+        (-> req
+            (update :headers add-forwarded-header)
+            (proxy proxy-url)))
+      (handler req))
+    handler))


### PR DESCRIPTION
Build out a small HTTP proxy middleware which can be used to catch specific requests during development and proxy the remaining requests out to the real remote server. Since Slack only lets us set one remote server for e.g. _all_ Slack events, this will make it easier to not disrupt usage (without making a second app).